### PR TITLE
feat(api/internal): add timelineId to TimelineEvent fragment and type…

### DIFF
--- a/src/app/api/internal/fragments/Timeline.graphql
+++ b/src/app/api/internal/fragments/Timeline.graphql
@@ -3,6 +3,7 @@ fragment TimelineEvent on TimelineEvent {
   date
   type
   title
+  timelineId
   description
   showTime
   url

--- a/src/app/api/internal/graphql.ts
+++ b/src/app/api/internal/graphql.ts
@@ -100,6 +100,7 @@ export type TimelineEvent = {
   date: string;
   type: TimelineType;
   title?: string | null;
+  timelineId: number;
   description?: string | null;
   showTime?: boolean | null;
   url?: string | null;
@@ -229,6 +230,7 @@ export const TimelineEvent = gql`
     date
     type
     title
+    timelineId
     description
     showTime
     url

--- a/src/app/api/internal/schema.graphql
+++ b/src/app/api/internal/schema.graphql
@@ -115,6 +115,7 @@ type TimelineEvent {
   previewlyImageId: Int
   showTime: Boolean
   tags: [String!]!
+  timelineId: Int!
   title: String
   type: TimelineType!
   url: String


### PR DESCRIPTION
… definition

This commit adds the `timelineId` field to the `TimelineEvent` fragment and type definition in the `api/internal` Graph